### PR TITLE
fix preprocessor detection: detect DELTA encoding

### DIFF
--- a/7z2hashcat.pl
+++ b/7z2hashcat.pl
@@ -11,13 +11,13 @@ use File::Basename;
 # magnum (added proper handling of BCJ et. al. and adapt to JtR use)
 
 # version:
-# 1.5
+# 1.6
 
 # date released:
 # April 2015
 
 # date last updated:
-# 20th Sep 2021
+# 3rd Dec 2021
 
 # dependencies:
 # Compress::Raw::Lzma
@@ -68,7 +68,11 @@ use File::Basename;
 # "$"
 # [length of data for CRC32]      # the length of the first "file" needed to verify the CRC32 checksum
 # "$"
-# [coder attributes]              # most of the coders/decompressors need some attributes (e.g. encoded lc, pb, lp, dictSize values);
+# [coder attributes]              # most of the coders/decompressors need some attributes (e.g. encoded lc, pb, lp, dictSize values)
+
+# in case a preprocessor is used, this field is appended:
+# "$"
+# [preprocessor attributes]       # the preprocessor attributes are appended after the main coder attributes
 
 #
 # Explanation of the data type indicator
@@ -92,7 +96,7 @@ use File::Basename;
 #   - 7 means that the data must be decompressed using the DEFLATE decompressor
 #   - 8 .. 15 reserved (future use)
 #
-# UPPER NIBBLE ((type >> 4) & 0x7)
+# UPPER NIBBLE (4 bits, (type >> 4) & 0xf)
 #   - 1 means that the data must be post-processed using BCJ (x86)
 #   - 2 means that the data must be post-processed using BCJ2 (four data streams needed)
 #   - 3 means that the data must be post-processed using PPC (big-endian)
@@ -100,6 +104,8 @@ use File::Basename;
 #   - 5 means that the data must be post-processed using ARM (little-endian)
 #   - 6 means that the data must be post-processed using ARMT (little-endian)
 #   - 7 means that the data must be post-processed using SPARC
+#   - 8 means that the data must be post-processed using DELTA
+#   - 9 .. 15 reserved (future use)
 
 # Truncated data can only be verified using the padding attack and therefore combinations between truncation + a compressor are not allowed.
 # Therefore, whenever the value is 128 or 0, neither coder attributes nor the length of the data for the CRC32 check is within the output.
@@ -133,7 +139,7 @@ my $PASSWORD_RECOVERY_TOOL_DATA_LIMIT = 16 * 1024 * 1024;    # hexadecimal outpu
 my $PASSWORD_RECOVERY_TOOL_SUPPORT_PADDING_ATTACK  = 0;      # does the cracker support the AES-CBC padding attack (0 means no, 1 means yes)
 my @PASSWORD_RECOVERY_TOOL_SUPPORTED_DECOMPRESSORS = (1, 2); # within this list we only need values ranging from 1 to 7
                                                              # i.e. SEVEN_ZIP_LZMA1_COMPRESSED to SEVEN_ZIP_DEFLATE_COMPRESSED
-my @PASSWORD_RECOVERY_TOOL_SUPPORTED_PREPROCESSORS = ( 0 ); # BCJ2 can be "supported" by ignoring CRC
+my @PASSWORD_RECOVERY_TOOL_SUPPORTED_PREPROCESSORS = ( 0 );  # BCJ2 can be "supported" by ignoring CRC
 
 # 7-zip specific stuff
 
@@ -194,6 +200,7 @@ my $SEVEN_ZIP_ARMT              = "\x03\x03\x07\x01";
 my $SEVEN_ZIP_SPARC             = "\x03\x03\x08\x05";
 my $SEVEN_ZIP_BZIP2             = "\x04\x02\x02";
 my $SEVEN_ZIP_DEFLATE           = "\x04\x01\x08";
+my $SEVEN_ZIP_DELTA             = "\x03";
 
 # hash format
 
@@ -215,12 +222,13 @@ my $SEVEN_ZIP_IA64_PREPROCESSED  =   4;
 my $SEVEN_ZIP_ARM_PREPROCESSED   =   5;
 my $SEVEN_ZIP_ARMT_PREPROCESSED  =   6;
 my $SEVEN_ZIP_SPARC_PREPROCESSED =   7;
+my $SEVEN_ZIP_DELTA_PREPROCESSED =   8;
 
 my $SEVEN_ZIP_TRUNCATED          = 128; # (0x80 or 0b10000000)
 
 my %SEVEN_ZIP_COMPRESSOR_NAMES   = (1 => "LZMA1", 2 => "LZMA2", 3 => "PPMD", 6 => "BZIP2", 7 => "DEFLATE",
                                     (1 << 4) => "BCJ", (2 << 4) => "BCJ2", (3 << 4) => "PPC", (4 << 4) => "IA64",
-                                    (5 << 4) => "ARM", (6 << 4) => "ARMT", (7 << 4) => "SPARC");
+                                    (5 << 4) => "ARM", (6 << 4) => "ARMT", (7 << 4) => "SPARC", (8 << 4) => "DELTA");
 
 #
 # Helper functions
@@ -1168,7 +1176,7 @@ sub extract_hash_from_archive
   }
   elsif ($codec_id ne $SEVEN_ZIP_AES)
   {
-    print STDERR "WARNING: unsupported coder with codec id '" . unpack ("H*", $codec_id) . "' in file '" . $file_path . "' found.\n";
+    print STDERR "WARNING: unsupported coder with codec id '0x" . unpack ("H*", $codec_id) . "' in file '" . $file_path . "' found.\n";
     print STDERR "If you think this codec method from DOC/Methods.txt of the 7-Zip source code ";
     print STDERR "should be supported, please file a problem report/feature request\n";
 
@@ -1195,7 +1203,7 @@ sub extract_hash_from_archive
 
   my $digest = get_digest ($digests_index, $unpack_info, $substreams_info);
 
-  return undef unless ((defined ($digest)) && ($digest->{'defined'} == 1));
+  return "" unless ((defined ($digest)) && ($digest->{'defined'} == 1));
 
   my $attributes = $coder->{'attributes'};
 
@@ -1238,9 +1246,10 @@ sub extract_hash_from_archive
     }
   }
 
-  my $type_of_compression    = $SEVEN_ZIP_UNCOMPRESSED;
-  my $type_of_preprocessor   = $SEVEN_ZIP_UNCOMPRESSED;
-  my $compression_attributes = "";
+  my $type_of_compression     = $SEVEN_ZIP_UNCOMPRESSED;
+  my $type_of_preprocessor    = $SEVEN_ZIP_UNCOMPRESSED;
+  my $compression_attributes  = "";
+  my $preprocessor_attributes = "";
 
   for (my $coder_pos = $coder_id + 1; $coder_pos < $number_coders; $coder_pos++)
   {
@@ -1248,6 +1257,8 @@ sub extract_hash_from_archive
     last unless (defined ($coder));
 
     $codec_id = $coder->{'codec_id'};
+
+    my $is_preprocessor = 0;
 
     if ($codec_id eq $SEVEN_ZIP_LZMA1)
     {
@@ -1261,34 +1272,6 @@ sub extract_hash_from_archive
     {
       $type_of_compression = $SEVEN_ZIP_PPMD_COMPRESSED;
     }
-    elsif ($codec_id eq $SEVEN_ZIP_BCJ)
-    {
-      $type_of_preprocessor = $SEVEN_ZIP_BCJ_PREPROCESSED;
-    }
-    elsif ($codec_id eq $SEVEN_ZIP_BCJ2)
-    {
-      $type_of_preprocessor = $SEVEN_ZIP_BCJ2_PREPROCESSED;
-    }
-    elsif ($codec_id eq $SEVEN_ZIP_PPC)
-    {
-      $type_of_preprocessor = $SEVEN_ZIP_PPC_PREPROCESSED;
-    }
-    elsif ($codec_id eq $SEVEN_ZIP_IA64)
-    {
-      $type_of_preprocessor = $SEVEN_ZIP_IA64_PREPROCESSED;
-    }
-    elsif ($codec_id eq $SEVEN_ZIP_ARM)
-    {
-      $type_of_preprocessor = $SEVEN_ZIP_ARM_PREPROCESSED;
-    }
-    elsif ($codec_id eq $SEVEN_ZIP_ARMT)
-    {
-      $type_of_preprocessor = $SEVEN_ZIP_ARMT_PREPROCESSED;
-    }
-    elsif ($codec_id eq $SEVEN_ZIP_SPARC)
-    {
-      $type_of_preprocessor = $SEVEN_ZIP_SPARC_PREPROCESSED;
-    }
     elsif ($codec_id eq $SEVEN_ZIP_BZIP2)
     {
       $type_of_compression = $SEVEN_ZIP_BZIP2_COMPRESSED;
@@ -1297,16 +1280,86 @@ sub extract_hash_from_archive
     {
       $type_of_compression = $SEVEN_ZIP_DEFLATE_COMPRESSED;
     }
-
-    if ($type_of_compression != $SEVEN_ZIP_UNCOMPRESSED)
+    elsif ($codec_id eq $SEVEN_ZIP_BCJ)
     {
-      if (defined ($coder->{'attributes'}))
-      {
-        $compression_attributes = unpack ("H*", $coder->{'attributes'});
-      }
+      $type_of_preprocessor = $SEVEN_ZIP_BCJ_PREPROCESSED;
+
+      $is_preprocessor = 1;
+    }
+    elsif ($codec_id eq $SEVEN_ZIP_BCJ2)
+    {
+      $type_of_preprocessor = $SEVEN_ZIP_BCJ2_PREPROCESSED;
+
+      $is_preprocessor = 1;
+    }
+    elsif ($codec_id eq $SEVEN_ZIP_PPC)
+    {
+      $type_of_preprocessor = $SEVEN_ZIP_PPC_PREPROCESSED;
+
+      $is_preprocessor = 1;
+    }
+    elsif ($codec_id eq $SEVEN_ZIP_IA64)
+    {
+      $type_of_preprocessor = $SEVEN_ZIP_IA64_PREPROCESSED;
+
+      $is_preprocessor = 1;
+    }
+    elsif ($codec_id eq $SEVEN_ZIP_ARM)
+    {
+      $type_of_preprocessor = $SEVEN_ZIP_ARM_PREPROCESSED;
+
+      $is_preprocessor = 1;
+    }
+    elsif ($codec_id eq $SEVEN_ZIP_ARMT)
+    {
+      $type_of_preprocessor = $SEVEN_ZIP_ARMT_PREPROCESSED;
+
+      $is_preprocessor = 1;
+    }
+    elsif ($codec_id eq $SEVEN_ZIP_SPARC)
+    {
+      $type_of_preprocessor = $SEVEN_ZIP_SPARC_PREPROCESSED;
+
+      $is_preprocessor = 1;
+    }
+    elsif ($codec_id eq $SEVEN_ZIP_DELTA)
+    {
+      $type_of_preprocessor = $SEVEN_ZIP_DELTA_PREPROCESSED;
+
+      $is_preprocessor = 1;
+    }
+    else
+    {
+      print STDERR "WARNING: unsupported coder with codec id '0x" . unpack ("H*", $codec_id) . "' in file '" . $file_path . "' found.\n";
+
+      return "";
     }
 
-    #print STDERR "Saw unknown codec '" . $codec_id . "'\n";
+    if ($is_preprocessor == 0)
+    {
+      if ($type_of_compression != $SEVEN_ZIP_UNCOMPRESSED)
+      {
+        if (defined ($coder->{'attributes'}))
+        {
+          $compression_attributes = unpack ("H*", $coder->{'attributes'});
+        }
+      }
+    }
+    else
+    {
+      if ($type_of_preprocessor != $SEVEN_ZIP_UNCOMPRESSED)
+      {
+        if (defined ($coder->{'attributes'}))
+        {
+          $preprocessor_attributes = unpack ("H*", $coder->{'attributes'});
+        }
+      }
+    }
+  }
+
+  if (length ($preprocessor_attributes) > 0) # special case: we need both attributes
+  {
+    $compression_attributes .= "\$" . $preprocessor_attributes;
   }
 
   # show a warning if the decompression algorithm is currently not supported by the cracker
@@ -1336,6 +1389,13 @@ sub extract_hash_from_archive
             print STDERR "the password recovery tool might be able to use that to verify the correctness of password candidates.\n";
             print STDERR "By using this attack there might of course be a higher probability of false positives.\n";
             print STDERR "\n";
+
+            if ($PASSWORD_RECOVERY_TOOL_SUPPORT_PADDING_ATTACK == 0)
+            {
+              print STDERR "$PASSWORD_RECOVERY_TOOL_NAME currently does not support padding attacks.\n";
+
+              return "";
+            }
           }
           elsif ($type_of_compression == $SEVEN_ZIP_LZMA2_COMPRESSED) # this special case should only work for LZMA2
           {
@@ -1516,7 +1576,7 @@ sub extract_hash_from_archive
                                       # that would help to achieve minimal RAM consumption (even for very large hashes)
   }
 
-  return undef unless (length ($data) == $data_len);
+  return "" unless (length ($data) == $data_len);
 
   if ($data_len > ($PASSWORD_RECOVERY_TOOL_DATA_LIMIT / 2))
   {
@@ -2362,20 +2422,6 @@ sub read_seven_zip_streams_info
   };
 
   return $streams_info;
-}
-
-sub folder_seven_zip_decode
-{
-  my $streams_info = shift;
-
-  my $number_coders = 0;
-
-  for (my $i = 0; $i < $number_coders; $i++)
-  {
-  }
-  #parse_folder ();
-
-  return;
 }
 
 sub read_seven_zip_archive_properties

--- a/README.md
+++ b/README.md
@@ -69,11 +69,12 @@ This is an overview of the output:
 | $ | [length of iv]             | yes              | the length of the initialization vector (values from 0 to 16)                                   |
 | $ | [iv]                       | yes              | the initialization vector in hexadecimal form                                                   |
 | $ | [CRC32]                    | yes              | the actual "hash" aka the CRC checksum in decimal form                                          |
-| $ | [length of encrypted data] | yes              | the length of the encrypted data (see [encrypted data])                                          |
+| $ | [length of encrypted data] | yes              | the length of the encrypted data (see [encrypted data])                                         |
 | $ | [length of decrypted data] | yes              | the length of the output of the AES decryption of [encrypted data]                              |
 | $ | [encrypted data]           | yes              | the encrypted data itself (this field in some cases could be truncated, see below)              |
 | $ | [length of data for CRC32] | no               | optional field indicating the length of the first "file" in case decompression needs to be used |
 | $ | [coder attributes]         | no               | optional field indicating the attributes for the decompressor                                   |
+| $ | [preprocessor attributes]  | no               | optional field indicating the attributes for the preprocessor                                   |
 
 The **data type indicator** is a special field and needs some further explanation:  
   
@@ -92,7 +93,7 @@ If no truncation is used/possible:
      - 6 means that the data must be decompressed using the BZIP2 decompressor
      - 7 means that the data must be decompressed using the DEFLATE decompressor
      - 8-15 reserved (future use)
-   - Upper nibble ((type >> 4) & 0x7):
+   - Upper nibble (4 bits, (type >> 4) & 0xf):
      - 1 means that the data must be post-processed using BCJ (x86)
      - 2 means that the data must be post-processed using BCJ2 (four data streams needed)
      - 3 means that the data must be post-processed using PPC (big-endian)
@@ -100,6 +101,8 @@ If no truncation is used/possible:
      - 5 means that the data must be post-processed using ARM (little-endian)
      - 6 means that the data must be post-processed using ARMT (little-endian)
      - 7 means that the data must be post-processed using SPARC
+     - 8 means that the data must be post-processed using DELTA
+     - 9-15 reserved (future use)
 
 Truncated data can only be verified using the padding attack and therefore combinations between truncation and a compressor are not meaningful/allowed.  
   


### PR DESCRIPTION
This pull request fixes a problem of `7z2hashcat.pl` that was first reported here: https://github.com/hashcat/hashcat/issues/3039 (`hashcat` github issue).

The problem was that not all coders, and especially not all preprocessors, were correctly identified and dealt with when combinations of compression + preprocessors were used when creating the `7z` archive.

In this particular case, the `Delta Encoding` (see https://en.wikipedia.org/wiki/Delta_encoding and https://en.wikipedia.org/wiki/7z#Pre-processing_filters) was NOT detected/recognized (because it was not within our list of preprocessing filters) and therefore crackers like `hashcat` did believe that the archive is just compressed (and that the data was NOT preprocessed, while it really was !).

For now we will just this extra code to detect DELTA and block it (while some crackers are still unable to deal with it). In the future, the crackers (`hashcat` or `john`) could just update the list of supported preprocessors/filters (see `PASSWORD_RECOVERY_TOOL_SUPPORTED_PREPROCESSORS` variable).

Thanks @469312306  for reporting